### PR TITLE
feat: Mission 엔티티 생성 및 MemberMission 매핑 추가

### DIFF
--- a/src/main/java/com/example/umc9th/domain/mission/entitiy/Mission.java
+++ b/src/main/java/com/example/umc9th/domain/mission/entitiy/Mission.java
@@ -1,0 +1,36 @@
+package com.example.umc9th.domain.mission.entitiy;
+
+import com.example.umc9th.domain.store.entitiy.Store;
+import com.example.umc9th.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "mission")
+@EntityListeners(AuditingEntityListener.class)
+public class Mission   {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "duration", nullable = false)
+    private LocalDate duration;
+
+    @Column(name = "conditional", nullable = false)
+    private String conditional;
+
+    @Column(name = "point", nullable = false)
+    private Integer point;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+}

--- a/src/main/java/com/example/umc9th/domain/mission/entitiy/mapping/MemberMission.java
+++ b/src/main/java/com/example/umc9th/domain/mission/entitiy/mapping/MemberMission.java
@@ -1,0 +1,29 @@
+package com.example.umc9th.domain.mission.entitiy.mapping;
+
+import com.example.umc9th.domain.member.entitiy.Member;
+import com.example.umc9th.domain.mission.entitiy.Mission;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "member_mission")
+public class MemberMission {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "is_complete", nullable = false)
+    private boolean isComplete = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id", nullable = false)
+    private Mission mission;
+}

--- a/src/main/java/com/example/umc9th/domain/store/entitiy/Store.java
+++ b/src/main/java/com/example/umc9th/domain/store/entitiy/Store.java
@@ -1,0 +1,15 @@
+package com.example.umc9th.domain.store.entitiy;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@Table(name = "store")
+public class Store {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+}


### PR DESCRIPTION
## 💡 작업 개요
Mission 관련 엔티티 생성 및 매핑 설정

## ✨ 작업 상세
- Mission 엔티티 생성 (`mission` 테이블)
  - mission_id (PK)
  - duration (date)
  - conditional (varchar)
  - point (int)
  - created_at (datetime)
  - store_id (FK → store)
- Store 엔티티와의 연관관계 설정 (ManyToOne)
- MemberMission 엔티티와의 연관관계 설정 (OneToMany)
- Auditing(BaseEntity) 적용

## 📁 관련 파일
- `Mission.java`
- `MemberMission.java` 
- `Store.java` 임의로 생성

## ✅ 완료 조건
- DB에 mission 테이블 정상 생성 확인
- 연관관계 매핑 시 정상적으로 테이블 조인 확인
- JPA 실행 시 에러 없이 DDL 자동 생성 완료
