### PR TITLE
refactor: BaseEntity 구조 분리 (생성일 / 수정일 분리)

### DIFF
--- a/src/main/java/com/example/umc9th/domain/member/entitiy/Member.java
+++ b/src/main/java/com/example/umc9th/domain/member/entitiy/Member.java
@@ -2,7 +2,7 @@ package com.example.umc9th.domain.member.entitiy;
 
 import com.example.umc9th.domain.member.enums.Gender;
 import com.example.umc9th.domain.member.enums.SocialType;
-import com.example.umc9th.global.entity.BaseEntity;
+import com.example.umc9th.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -16,7 +16,7 @@ import java.time.LocalDate;
 @Getter
 @Table(name = "member")
 @EntityListeners(AuditingEntityListener.class)
-public class Member extends BaseEntity {
+public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/umc9th/domain/mission/entitiy/Mission.java
+++ b/src/main/java/com/example/umc9th/domain/mission/entitiy/Mission.java
@@ -1,7 +1,7 @@
 package com.example.umc9th.domain.mission.entitiy;
 
 import com.example.umc9th.domain.store.entitiy.Store;
-import com.example.umc9th.global.entity.BaseEntity;
+import com.example.umc9th.global.entity.BaseCreatedEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -15,7 +15,7 @@ import java.time.LocalDate;
 @Getter
 @Table(name = "mission")
 @EntityListeners(AuditingEntityListener.class)
-public class Mission   {
+public class Mission extends BaseCreatedEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/umc9th/global/entity/BaseCreatedEntity.java
+++ b/src/main/java/com/example/umc9th/global/entity/BaseCreatedEntity.java
@@ -1,0 +1,20 @@
+package com.example.umc9th.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseCreatedEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/umc9th/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/example/umc9th/global/entity/BaseTimeEntity.java
@@ -4,19 +4,15 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-@Getter
-public abstract class BaseEntity {
-    @CreatedDate
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
+public abstract class BaseTimeEntity extends BaseCreatedEntity {
 
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)


### PR DESCRIPTION
- BaseCreatedEntity: created_at만 관리
- BaseTimeEntity: created_at + updated_at 관리
- Mission 엔티티 → BaseCreatedEntity 상속으로 변경
- Member 엔티티 → BaseTimeEntity 상속으로 유지
- 불필요한 updated_at 컬럼이 mission 테이블에서 제거되도록 구조 개선